### PR TITLE
タイマー加算がなくなっていたのを修正

### DIFF
--- a/UnityProject/Assets/Prefab/GameCtrl.prefab
+++ b/UnityProject/Assets/Prefab/GameCtrl.prefab
@@ -72,5 +72,5 @@ MonoBehaviour:
   span: 0.16
   Phase: 0
   ReturnVC: 0
-  addTimeVanishCount: 12
-  addTime: 0
+  addTimeVanishCount: 15
+  addTime: 0.5

--- a/UnityProject/Assets/Resources/Script/Timer.cs
+++ b/UnityProject/Assets/Resources/Script/Timer.cs
@@ -80,27 +80,7 @@ public class Timer : MonoBehaviour {
 
         if (timeOut == false)
         {
-            int second = (int)Seconds;
-            int minutes = (int)Minutes;
-            int work;
-
-            for (int i = 0; i < numberPointList.Count; i++)
-            {
-                if (i < 2)
-                {    //  秒の計算
-                    work = second % 10;
-                    Point number = numberPointList[i].GetComponent<Point>();
-                    number.SetNumber(work);
-                    second = second / 10;
-                }
-                else
-                {      //  分の計算
-                    work = minutes % 10;
-                    Point number = numberPointList[i].GetComponent<Point>();
-                    number.SetNumber(work);
-                    minutes = minutes / 10;
-                }
-            }
+            ResetTime();
         }
     }
 
@@ -138,8 +118,10 @@ public class Timer : MonoBehaviour {
     {
         if (timeOut)
         {
-            Seconds += time;
+            return;
         }
+
+        Seconds += time;
 
         if (Seconds >= FPS)
         {


### PR DESCRIPTION
## 概要
タイマー加算がされていなかったのを修正
フィニッシュ後にコンボでタイマー加算されるバグを修正

## デバッグ方法
ゲームをプレイしてタイマー加算をチェック
ゲームフィニッシュ時にタイマーが加算されていないことをチェック

## デバッグしてほしい人
暇な人